### PR TITLE
Add host pseudoselector to CSS tokens

### DIFF
--- a/build/css/breakpoints.css
+++ b/build/css/breakpoints.css
@@ -2,7 +2,7 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root {
+:root, :host {
   --usa-breakpoint-card: 10rem;
   --usa-breakpoint-card-lg: 15rem;
   --usa-breakpoint-mobile: 20rem;

--- a/build/css/colors.css
+++ b/build/css/colors.css
@@ -2,7 +2,7 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root {
+:root, :host {
   --usa-color-black-transparent-5: rgba(0,0,0,0.01);
   --usa-color-black-transparent-10: rgba(0,0,0,0.1);
   --usa-color-black-transparent-20: rgba(0,0,0,0.2);

--- a/build/css/spacing.css
+++ b/build/css/spacing.css
@@ -2,7 +2,7 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root {
+:root, :host {
   --usa-column-gap-0: 0px;
   --usa-column-gap-1: 0.5rem;
   --usa-column-gap-2: 1rem;

--- a/build/css/typography.css
+++ b/build/css/typography.css
@@ -2,7 +2,7 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-:root {
+:root, :host {
   --usa-font-family-system: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   --usa-font-family-georgia: Georgia, Cambria, "Times New Roman", Times, serif;
   --usa-font-family-helvetica: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;

--- a/config/style-dictionary.config.js
+++ b/config/style-dictionary.config.js
@@ -63,6 +63,9 @@ export default {
       files: outputs.map(({ name, filter }) => ({
         destination: `${name}.css`,
         format: "css/variables",
+        options: {
+          selector: ":root, :host",
+        },
         filter,
       })),
     },


### PR DESCRIPTION
Currently, the generated CSS tokens define variables on the `:root` pseudoselector. This is useful for many contexts, but makes the tokens harder to consume inside of web components that leverage shadow DOM. In order to make it easier to use the tokens in web components, this PR configures style dictionary to define the styles on `:root, :host` instead of just `:root`.

In the component that consumes the tokens, they can be imported as any other dependency:

```js
import colorTokens from "@ogds/tokens/styles/css/colors.css";
import spacingTokens from "@ogds/tokens/styles/css/spacing.css";
import breakpointTokens from "@ogds/tokens/styles/css/breakpoints.css";
```
and then leveraged like other CSS in the component (example here uses Lit's styles as in OGDS/USWDS Elements):

```js
static styles = [
  breakpointTokens,
  colorTokens,
  spacingTokens,
  styles, // whatever other styles the component imports or defines 
];
```
